### PR TITLE
Gradle plugin update to 7.2, target SDK 32, Java 11 support, Updated all dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,11 +3,11 @@
 buildscript {
     ext.versions = [
             'minSdk': 21,
-            'compileSdk': 29,
-            'targetSdk': 29,
-            'buildTools':'29.0.3',
+            'compileSdk': 32,
+            'targetSdk': 32,
+            'buildTools':'32.1.0-rc1',
 
-            'kotlin':'1.5.31'
+            'kotlin':'1.6.10'
     ]
 
      repositories {
@@ -15,7 +15,7 @@ buildscript {
          google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath "org.jetbrains.kotlinx:binary-compatibility-validator:0.7.0"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.5.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jun 18 20:02:49 CEST 2020
+#Sat Mar 05 09:56:26 IST 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/pdfview-android/build.gradle
+++ b/pdfview-android/build.gradle
@@ -11,19 +11,20 @@ android {
         targetSdkVersion versions.targetSdk
     }
 
-    buildTypes {
-        debug {
-            debuggable = true
-        }
-        release {
-            debuggable = false
-        }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
+
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
-    implementation 'androidx.annotation:annotation:1.2.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}"
+    implementation 'androidx.annotation:annotation:1.3.0'
 }
 
 apply from: "$rootDir/maven-scripts/publish-module.gradle"

--- a/sample-local/build.gradle
+++ b/sample-local/build.gradle
@@ -2,15 +2,25 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 32
     defaultConfig {
         applicationId "com.pdfview_sample.sample"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
+    }
+
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+
     buildTypes {
         release {
             minifyEnabled false
@@ -22,10 +32,10 @@ android {
 dependencies {
     implementation 'com.dmitryborodin:pdfview-android:1.1.0'
 //    implementation project(':pdfview-android')
-    implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$versions.kotlin"
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.1'
-    testImplementation 'junit:junit:4.13'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk8:$versions.kotlin"
+    implementation 'androidx.appcompat:appcompat:1.4.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }

--- a/sample-local/src/main/AndroidManifest.xml
+++ b/sample-local/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/sample-network/build.gradle
+++ b/sample-network/build.gradle
@@ -2,18 +2,25 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 32
     defaultConfig {
         applicationId "com.pdfview_sample.sample"
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
+
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+
     buildTypes {
         release {
             minifyEnabled false
@@ -25,14 +32,14 @@ android {
 dependencies {
 //    implementation 'com.pdfview:pdfview-android:1.0.0'
     implementation project(':pdfview-android')
-    implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$versions.kotlin"
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk8:$versions.kotlin"
+    implementation 'androidx.appcompat:appcompat:1.4.1'
     //this provides toUri(), by viewModel and other extensions
-    implementation "androidx.fragment:fragment-ktx:1.2.5"
+    implementation "androidx.fragment:fragment-ktx:1.4.1"
 
     implementation 'com.squareup.okhttp3:okhttp:4.7.2'
 
-    testImplementation 'junit:junit:4.13'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }

--- a/sample-network/src/main/AndroidManifest.xml
+++ b/sample-network/src/main/AndroidManifest.xml
@@ -11,7 +11,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
Set target and compile SDK version to API 32.
Upgraded Gradle version to 7.1.2.
Built project in Android Studio 2021.1.1 Patch 2 (Bumblebee).
Added Java 11 support to project.
Updated project Kotlin version to 1.6.10
Updated all internal dependencies.